### PR TITLE
Add option to hide badge on toolbar icon

### DIFF
--- a/background.js
+++ b/background.js
@@ -23,6 +23,7 @@ const wait = 60;
 
 const settings = {
 	icon: null,
+	badge: null,
 	color: null,
 	warndays: null, // Days
 	open: null,
@@ -192,14 +193,17 @@ function setIcon(tabId, icon, title, text, backgroundColor) {
 		title,
 		tabId
 	});
-	browser.browserAction.setBadgeText({
-		text,
-		tabId
-	});
-	browser.browserAction.setBadgeBackgroundColor({
-		color: backgroundColor,
-		tabId
-	});
+
+	if(settings.badge) {
+		browser.browserAction.setBadgeText({
+			text,
+			tabId
+		});
+		browser.browserAction.setBadgeBackgroundColor({
+			color: backgroundColor,
+			tabId
+		});
+	}
 }
 
 /**
@@ -1052,6 +1056,7 @@ function setSettings(asettings) {
 	settings.map = Number.parseInt(asettings.map, 10);
 	settings.lookup = Number.parseInt(asettings.lookup, 10);
 	settings.icon = Number.parseInt(asettings.icon, 10);
+	settings.badge = asettings.badge;
 	settings.dns = asettings.dns;
 	settings.blacklist = asettings.blacklist;
 	settings.domainblacklists = [asettings.domainblacklist];

--- a/common/modules/data/DefaultSettings.js
+++ b/common/modules/data/DefaultSettings.js
@@ -14,6 +14,7 @@
 const defaultSettings = {
 	settings: {
 		icon: "1",
+		badge: true,
 		color: "#0000ff", // Blue
 		warndays: 3, // Days
 		open: false,

--- a/options/options.html
+++ b/options/options.html
@@ -176,6 +176,12 @@
 								<label for="color">Default background color in toolbar</label>
 							</div>
 						</li>
+						<li>
+							<div class="line">
+								<input class="setting save-on-change" type="checkbox" id="badge" data-optiongroup="settings" name="badge">
+								<label for="badge">Display badge on toolbar icon</label>
+							</div>
+						</li>
 					</ul>
 				</li>
 			</ul>


### PR DESCRIPTION
Thanks for your work on this - I haven't seen this wealth of info an any other extensions!

This adds an optional toggle to hide the badge on the toolbar icon, which I generally find a bit distracting on extensions. 

![image](https://github.com/tdulcet/Server-Status/assets/904055/89dc3e7b-dc31-4ac8-93d1-f47488b0e8e7)

![image](https://github.com/tdulcet/Server-Status/assets/904055/19f73037-b2df-4644-8812-39f2c28a9356)
